### PR TITLE
Add support for region detection for Oracle

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -104,6 +104,9 @@ var elbAmazonRegex = regexp.MustCompile(`elb(.*?).amazonaws.com$`)
 // Regular expression used to determine if the arg is elb host in china.
 var elbAmazonCnRegex = regexp.MustCompile(`elb(.*?).amazonaws.com.cn$`)
 
+// Regular expression used to determine if the arg is oracle s3 compatibility host.
+var oracleS3CompatibilityRegex = regexp.MustCompile(`^.+?.compat.objectstorage.(.*?).oraclecloud.com$`)
+
 // GetRegionFromURL - returns a region from url host.
 func GetRegionFromURL(endpointURL url.URL) string {
 	if endpointURL == sentinelURL {
@@ -136,6 +139,10 @@ func GetRegionFromURL(endpointURL url.URL) string {
 		return parts[1]
 	}
 	parts = amazonS3HostDot.FindStringSubmatch(endpointURL.Host)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	parts = oracleS3CompatibilityRegex.FindStringSubmatch(endpointURL.Host)
 	if len(parts) > 1 {
 		return parts[1]
 	}

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -99,6 +99,12 @@ func TestGetRegionFromURL(t *testing.T) {
 				Host: "s3.kubernetesfrontendlb-caf78da2b1f7516c.elb.amazonaws.com.cn",
 			},
 		},
+		{
+			u: url.URL{
+				Host: "abcd123.compat.objectstorage.us-ashburn-1.oraclecloud.com",
+			},
+			expectedRegion: "us-ashburn-1",
+		},
 	}
 
 	for i, testCase := range testCases {

--- a/utils_test.go
+++ b/utils_test.go
@@ -73,6 +73,8 @@ func TestGetEndpointURL(t *testing.T) {
 		{"192.168.1.1:9000", false, "http://192.168.1.1:9000", nil, true},
 		{"192.168.1.1:9000", true, "https://192.168.1.1:9000", nil, true},
 		{"s3.amazonaws.com:443", true, "https://s3.amazonaws.com:443", nil, true},
+		{"abcd123.compat.objectstorage.us-ashburn-1.oraclecloud.com", true, "https://abcd123.compat.objectstorage.us-ashburn-1.oraclecloud.com", nil, true},
+		{"abcd123.compat.objectstorage.uk-london-1.oraclecloud.com", true, "https://abcd123.compat.objectstorage.uk-london-1.oraclecloud.com", nil, true},
 		{"13333.123123.-", true, "", errInvalidArgument(fmt.Sprintf("Endpoint: %s does not follow ip address or domain name standards.", "13333.123123.-")), false},
 		{"13333.123123.-", true, "", errInvalidArgument(fmt.Sprintf("Endpoint: %s does not follow ip address or domain name standards.", "13333.123123.-")), false},
 		{"storage.googleapis.com:4000", true, "", errInvalidArgument("Google Cloud Storage endpoint should be 'storage.googleapis.com'."), false},
@@ -122,6 +124,7 @@ func TestIsValidEndpointURL(t *testing.T) {
 		{"https://storage.googleapis.com/", nil, true},
 		{"https://z3.amazonaws.com", nil, true},
 		{"https://mybalancer.us-east-1.elb.amazonaws.com", nil, true},
+		{"https://abcd123.compat.objectstorage.us-ashburn-1.oraclecloud.com", nil, true},
 		{"192.168.1.1", errInvalidArgument("Endpoint url cannot have fully qualified paths."), false},
 		{"https://amazon.googleapis.com/", errInvalidArgument("Google Cloud Storage endpoint should be 'storage.googleapis.com'."), false},
 		{"https://storage.googleapis.com/bucket/", errInvalidArgument("Endpoint url cannot have fully qualified paths."), false},
@@ -197,6 +200,12 @@ func TestDefaultBucketLocation(t *testing.T) {
 			endpointURL:      url.URL{Host: "s3.amazonaws.com"},
 			regionOverride:   "",
 			expectedLocation: "us-east-1",
+		},
+		// Oracle. No region override, url based preferenced is honored - Test 7.
+		{
+			endpointURL:      url.URL{Host: "abcd123.compat.objectstorage.us-ashburn-1.oraclecloud.com"},
+			regionOverride:   "",
+			expectedLocation: "us-ashburn-1",
 		},
 	}
 


### PR DESCRIPTION
Oracle Cloud Infrastructure S3 Compatibility API uses [a custom URL scheme](https://docs.oracle.com/en-us/iaas/api/#/en/s3objectstorage/20160918/). 
This PR adds support for region detection for the OCI scheme.
 